### PR TITLE
license/disclaimer: adds BATTERY2030+ license and disclaimer

### DIFF
--- a/app_data/vocabularies/licenses.csv
+++ b/app_data/vocabularies/licenses.csv
@@ -34,7 +34,7 @@ artistic-1.0;Artistic License 1.0;;;all,software;https://opensource.org/licenses
 artistic-1.0-perl;Artistic License 1.0 (Perl);;;all,software;http://dev.perl.org/licenses/artistic.html;spdx;y
 artistic-1.0-cl8;Artistic License 1.0 w/clause 8;;;all,software;https://opensource.org/licenses/Artistic-1.0;spdx;y
 artistic-2.0;Artistic License 2.0;;;all,software;http://www.perlfoundation.org/artistic_license_2_0;spdx;y
-bm-1.0;BIG-MAP Archive License;The BIG-MAP Archive License allows re-distribution and re-use of work within the BIG-MAP community.;;recommended,all,data,software;https://www.big-map.eu/;spdx;
+bm-1.0;BATTERY2030+ License;The BATTERY2030+ License allows re-distribution and re-use of work within the communities of the BATTERY2030+ consortium.;;recommended,all,data,software;https://archive.big-map.eu/licenses/nonexclusive-distrib/1.1;spdx;
 bsd-1-clause;BSD 1-Clause License;;;all,software;https://svnweb.freebsd.org/base/head/include/ifaddrs.h?revision=326823;spdx;y
 bsd-2-clause;"BSD 2-Clause ""Simplified"" License";;;all,software;https://opensource.org/licenses/BSD-2-Clause;spdx;y
 bsd-2-clause-patent;BSD-2-Clause Plus Patent License;;;all,software;https://opensource.org/licenses/BSDplusPatent;spdx;y

--- a/assets/js/invenio_app_rdm/BMASubmitReviewModal.js
+++ b/assets/js/invenio_app_rdm/BMASubmitReviewModal.js
@@ -40,7 +40,12 @@ export class BMASubmitReviewModal extends Component {
     const directPublishCase = () => {
       headerTitle = "";
       msgWarningTitle = i18next.t(
-        "Once your record is shared with the {{communityTitle}} community, you can no longer make it private to you or change the community that it is shared with.",
+        "Once your record is shared with the <bold>{{communityTitle}}</bold> community,\
+        you can no longer make it private to you or change the community that it is shared with.<new_line/>\
+        By clicking on 'Share with community', you acknowledge that you have read and understood the terms\
+        of the license that you have chosen for your data, and that you agree to the content of the\
+        BIG-MAP Archive <disclaimerLink>disclaimer</disclaimerLink>.\
+        ",
           { communityTitle }
       );
       msgWarningText1 = i18next.t(
@@ -116,7 +121,13 @@ export class BMASubmitReviewModal extends Component {
                 <Message visible warning>
                   <p>
                     <Icon name="warning sign" />
-                    {msgWarningTitle}
+                    <Trans
+                      defaults={msgWarningTitle}
+                      values={{
+                        communityTitle: communityTitle,
+                      }}
+                      components={{disclaimerLink: <a href='/about/disclaimer' target='_blank'>Read disclaimer</a>, bold: <b />, new_line: <br /> }}
+                    />
                   </p>
                 </Message>
                   {!record && (

--- a/assets/less/site/globals/site.overrides
+++ b/assets/less/site/globals/site.overrides
@@ -261,6 +261,10 @@ div.ui.blue.tiny.horizontal.label {
     margin-top: 0px !important;
 }
 
+.vertical_align_middle {
+    vertical-align: middle !important;
+}
+
 /* Banners */
 
 .bma_banner {

--- a/invenio.cfg
+++ b/invenio.cfg
@@ -130,6 +130,7 @@ APP_RDM_DETAIL_SIDE_BAR_TEMPLATES = [
     "invenio_app_rdm/records/details/side_bar/versions.html",
     "invenio_app_rdm/records/details/side_bar/export.html",
     "invenio_app_rdm/records/details/side_bar/licenses.html",
+    "invenio_app_rdm/records/details/side_bar/disclaimer.html",
 ]
 
 
@@ -145,11 +146,11 @@ APP_RDM_DEPOSIT_FORM_DEFAULTS = {
     "rights": [
         {
             "id": "bm-1.0",
-            "title": "BIG-MAP Archive License",
-            "description": ("The BIG-MAP Archive License allows "
-                            "re-distribution and re-use of work "
-                            "within the BIG-MAP community."),
-            "link": "https://www.big-map.eu/",
+            "title": "BATTERY2030+ License",
+            "description": ("The BATTERY2030+ License allows re-distribution"
+                            " and re-use of work within the communities"
+                            " of the BATTERY2030+ consortium."),
+            "link": "/licenses/nonexclusive-distrib/1.1",
         }
     ],
     "publisher": "BIG-MAP Archive"

--- a/site/big_map_archive/infos.py
+++ b/site/big_map_archive/infos.py
@@ -5,9 +5,10 @@
 # BIG-MAP Archive is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
-"""Routes for faqs pages."""
+"""BIG-MAP Archive routes."""
 
 from flask import render_template
+
 
 def faqs():
     """FAQs page."""
@@ -15,14 +16,30 @@ def faqs():
         "big_map_archive/faqs.html",
     )
 
+
 def share_links():
     """Share links page."""
     return render_template(
         "big_map_archive/share_links.html",
     )
 
+
 def tutorial():
     """Tutorial page."""
     return render_template(
         "big_map_archive/tutorial.html",
+    )
+
+
+def licenses():
+    """BATTERY2030+ license page."""
+    return render_template(
+        "big_map_archive/license.html",
+    )
+
+
+def disclaimer():
+    """Disclaimer page."""
+    return render_template(
+        "big_map_archive/disclaimer.html",
     )

--- a/site/big_map_archive/templates/semantic-ui/big_map_archive/disclaimer.html
+++ b/site/big_map_archive/templates/semantic-ui/big_map_archive/disclaimer.html
@@ -1,0 +1,52 @@
+{#
+    -*- coding: utf-8 -*-
+    Copyright (C) 2024 BIG-MAP Archive Team.
+#}
+
+{%- set title = _("Disclaimer") %}
+{% extends "invenio_theme/page.html" %}
+
+{% block page_body %}
+{%- block grid_section %}
+    <div class="ui stackable grid container rel-mt-3">
+    {% block main_column %}
+        <div class="column one wide"></div>
+        <div class="column fourteen wide">
+            <h2>Disclaimer</h2>
+            <div class="pt-25"></div>
+            <div>
+                <p>
+                BIG-MAP Archive does not warrant that the <a href="/">Website</a> and the <a href="https://github.com/materialscloud-org/big-map-archive-api-client">API Client</a> will be uninterrupted,
+                timely, secure, or error-free;
+                that the information provided through the Website is accurate, reliable or correct;
+                that any defects or errors will be corrected;
+                that the Website and the API Client will be available at any particular time or location;
+                or that the Website and the API Client are free of viruses or other harmful components.
+                You assume full responsibility and risk of loss resulting from your downloading,
+                uploading and/or use of files, information, content or other material obtained from the Website and the API Client.
+                </p>
+                <p>
+                In the BIG-MAP Archive, data is always shared within a project (called hereafter a “COMMUNITY”)
+                that is part of the broader BATTERY 2030+ consortium. An additional COMMUNITY is also available
+                to share data with the BATTERY 2030+ consortium as a whole. The list of the members of each
+                COMMUNITY is managed by its project board of directors, or the person or persons appointed by
+                them to accomplish the task of user management, and can change over time.
+                </p>
+                <p>
+                Current, former and future COMMUNITY members are not authorised to distribute any records datasets
+                and the corresponding metadata outside the COMMUNITY in which the records were originally shared.
+                The BIG-MAP Archive has no control over and is not responsible for the misuse or breach of
+                confidentiality of the datasets by one or more of the COMMUNITY members, and is not responsible
+                for any data leak or misuse.
+                </p>
+            </div>
+            <div class="pt-25"></div>
+        </div>
+    {% endblock main_column %}
+    </div>
+{%- endblock grid_section %}
+{% endblock page_body %}
+
+{%- block javascript %}
+    {% include config.THEME_JAVASCRIPT_TEMPLATE %}
+{%- endblock javascript %}

--- a/site/big_map_archive/templates/semantic-ui/big_map_archive/license.html
+++ b/site/big_map_archive/templates/semantic-ui/big_map_archive/license.html
@@ -1,0 +1,78 @@
+{#
+    -*- coding: utf-8 -*-
+    Copyright (C) 2024 BIG-MAP Archive Team.
+#}
+
+{%- set title = _("BATTERY2030+ license") %}
+{% extends "invenio_theme/page.html" %}
+
+{% block page_body %}
+{%- block grid_section %}
+    <div class="ui stackable grid container rel-mt-3">
+    {% block main_column %}
+        <div class="column one wide"></div>
+        <div class="column fourteen wide">
+            <h2>BATTERY2030+ non-exclusive license to distribute</h2>
+            <div class="pt-25"></div>
+            <div>
+                <h3>License</h3>
+                <p>
+                    The URI <a href="/licenses/nonexclusive-distrib/1.1">https://archive.big-map.eu/licenses/nonexclusive-distrib/1.1</a>
+                    is used to record the fact that the submitter granted the following license to the BIG-MAP Archive
+                    upon the upload and share of a dataset and corresponding metadata within a project
+                    (called hereafter a “COMMUNITY”) that is part of the broader BATTERY 2030+ consortium:
+                    <ul>
+                    <li>
+                        I grant the BIG-MAP Archive a perpetual, non-exclusive license to distribute
+                        this dataset and metadata; this license is limited to distribution to current and
+                        future members of the COMMUNITY.
+                    </li>
+                    <li>I certify that I have the right to grant this license.</li>
+                    <li>
+                        Current, former and future COMMUNITY members are not authorised to distribute this dataset
+                        and the corresponding metadata outside the COMMUNITY in which it was originally shared.
+                        The BIG-MAP Archive has no control over and is not responsible for the misuse or breach
+                        of confidentiality of the dataset by one or more of the COMMUNITY members, and is not
+                        responsible for any data leak or misuse.
+                    </li>
+                    <li>
+                        I understand that, if  BATTERY 2030+ as a whole is selected, records are shared with all
+                        current and future members of all the COMMUNITIES present in the BATTERY 2030+ consortium.
+                    </li>
+                    <li>I understand that the list of the members of each COMMUNITY is managed by its project
+                        board of directors, or the person or persons appointed by them to accomplish the task
+                        of user management, and can change over time.
+                    </li>
+                    <li>
+                        I understand that records cannot be completely removed once uploaded.
+                    </li>
+                    <li>
+                        I understand that the BIG-MAP Archive reserves the right to reclassify or remove any record.
+                    </li>
+                    <li>
+                        NON-LIABILITY DISCLAIMER: I understand that the services of the BIG-MAP Archive are offered
+                        on an as-is basis, without any implicit or explicit warranty that data cannot be lost,
+                        misused, or re-distributed.
+                    </li>
+                    </ul>
+                </p>
+                <h3>Revision history</h3>
+                <p>
+                    2024-06-10 - version 1.1 - License adapted and extended to a BATTERY2030+ license, to include the concept of COMMUNITIES.
+                </p>
+                <p>
+                    2022-11-21 - version 1.0 - BIG-MAP Archive License for BIG-MAP Archive metadata and datasets upload,
+                    drawing upon the
+                    <a href="https://arxiv.org/licenses/nonexclusive-distrib/1.0/license.html" target="_blank">arXiv.org non-exclusive license</a>.
+                </p>
+            </div>
+            <div class="pt-25"></div>
+        </div>
+    {% endblock main_column %}
+    </div>
+{%- endblock grid_section %}
+{% endblock page_body %}
+
+{%- block javascript %}
+    {% include config.THEME_JAVASCRIPT_TEMPLATE %}
+{%- endblock javascript %}

--- a/site/big_map_archive/views.py
+++ b/site/big_map_archive/views.py
@@ -9,7 +9,7 @@ from flask_security.utils import url_for_security
 from invenio_previewer.proxies import current_previewer
 
 from .deposits import deposit_edit
-from .infos import faqs, share_links, tutorial
+from .infos import disclaimer, faqs, licenses, share_links, tutorial
 
 #
 # BIG-MAP Archive blueprint
@@ -40,6 +40,8 @@ def create_blueprint(app):
         "faqs": "/help/faqs",
         "share_links": "/help/share_links",
         "tutorial": "/help/tutorial",
+        "licenses": "/licenses/nonexclusive-distrib/1.1",
+        "disclaimer": "/about/disclaimer",
     }
 
     # override views functions
@@ -87,22 +89,34 @@ def create_blueprint(app):
         template_folder="./templates",
     )
 
-    # "/help/faqs",
+    # "/help/faqs"
     blueprint.add_url_rule(
         routes_bmarchive["faqs"],
         view_func=faqs,
     )
 
-    # "/help/share_links",
+    # "/help/share_links"
     blueprint.add_url_rule(
         routes_bmarchive["share_links"],
         view_func=share_links,
     )
 
-    # "/help/tutorial",
+    # "/help/tutorial"
     blueprint.add_url_rule(
         routes_bmarchive["tutorial"],
         view_func=tutorial,
+    )
+
+    # "/licenses/nonexclusive-distrib/1.1"
+    blueprint.add_url_rule(
+        routes_bmarchive["licenses"],
+        view_func=licenses,
+    )
+
+    # "/about/disclaimer"
+    blueprint.add_url_rule(
+        routes_bmarchive["disclaimer"],
+        view_func=disclaimer,
     )
 
     # Add URL rules

--- a/templates/semantic-ui/invenio_accounts/forgot_password.html
+++ b/templates/semantic-ui/invenio_accounts/forgot_password.html
@@ -24,6 +24,23 @@
       <p class="reset">{{ message }}</p>
       {%- endfor %}
     {%- else %}
+      <div class="ui visible warning message bma_banner">
+        <p>
+          <i aria-hidden="true" class="warning sign icon"></i>
+          By logging in, you agree to the limitations on the redistribution of data and metadata
+          uploaded to the Archive.
+        </p>
+        <p>
+          <label for="reset_password_checkbox">
+            <input
+            type="checkbox"
+            class="vertical_align_middle"
+            id="reset_password_checkbox"
+            onchange="document.getElementById('reset_password').disabled = !this.checked;"></input>
+            I have read the BIG-MAP Archive <a href="/about/disclaimer" target="_blank">disclaimer</a>.
+          </label>
+        </p>
+      </div>
       <p class="reset">
         {{_('Enter your email address below, and a link to reset your password will be sent to you.')}}
       </p>
@@ -31,7 +48,7 @@
       <form action="{{ url_for_security('forgot_password') }}" method="POST" name="forgot_password_form">
         {{ form.hidden_tag() }}
         {{ render_field(form.email, icon="user icon", autofocus=True, errormsg='email' in form.errors) }}
-        <button type="submit" class="ui fluid large submit primary button">{{_('Reset password')}}</button>
+        <button type="submit" class="ui fluid large submit primary button" id="reset_password" disabled="true">{{_('Reset password')}}</button>
       </form>
       {%- endwith %}
     {%- endif %}

--- a/templates/semantic-ui/invenio_accounts/login_user.html
+++ b/templates/semantic-ui/invenio_accounts/login_user.html
@@ -16,6 +16,18 @@
       <div class="divider hidden"></div>
       {%- block form_header %}
         <h3 class="ui login header">Log in to {{config.THEME_SITENAME}}</h3>
+        <div class="ui visible warning message bma_banner">
+          <p>
+            <div class="divider hidden"></div>
+            <i aria-hidden="true" class="warning sign icon"></i>By logging in, you agree to the limitations on
+            the redistribution of data and metadata
+            uploaded to the Archive.<br/>
+          </p>
+          <p>
+            <div class="divider hidden"></div>
+            Please read the BIG-MAP Archive <a href="/about/disclaimer" target="_blank">disclaimer</a>.
+          </p>
+        </div>
         <p>
             Access to the data repository is restricted. To request an account, please email us at
             <span>

--- a/templates/semantic-ui/invenio_app_rdm/footer.html
+++ b/templates/semantic-ui/invenio_app_rdm/footer.html
@@ -15,9 +15,11 @@
         <div class="ui grid">
           {%- block footer_top_left %}
           <div class="rdm-footer six wide tablet two wide computer column">
-            <h2 class="ui small header">{{_ ("Archives")}}</h2>
-            <p><a href="https://archive.big-map.eu/">Main</a></p>
-            <p><a href="https://big-map-archive-demo.materialscloud.org/">Demo</a></p>
+            <h2 class="ui small header">{{_ ("About")}}</h2>
+            <p><a href="/licenses/nonexclusive-distrib/1.1" target="_blank">License</a></p>
+            <p><a href="/about/disclaimer" target="_blank">Disclaimer</a></p>
+            <p><a href="https://big-map-archive-demo.materialscloud.org/" target="_blank">Demo site</a></p>
+            <p><a href="mailto:big-map-archive@materialscloud.org">Contact</a></p>
           </div>
           <div class="rdm-footer six wide tablet two wide computer column">
             <h2 class="ui small header">{{_ ("REST API")}}</h2>
@@ -47,10 +49,6 @@
             <p><a href="/help/share_links" target="_blank">Share links</a></p>
             <p><a href="/help/statistics" target="_blank">Usage statistics</a></p>
             <p><a href="/help/tutorial" target="_blank">Tutorial</a></p>
-          </div>
-          <div class="rdm-footer six wide tablet six wide computer column">
-            <h2 class="ui small header">{{_ ("Contact")}}</h2>
-            <p>big-map-archive@materialscloud.org</p>
           </div>
           {%- endblock footer_top_left %}
           <div class="six wide column right aligned">

--- a/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/disclaimer.html
+++ b/templates/semantic-ui/invenio_app_rdm/records/details/side_bar/disclaimer.html
@@ -1,0 +1,40 @@
+{#
+  -*- coding: utf-8 -*-
+  Copyright (C) 2024 BIG-MAP Archive Team.
+#}
+<div class="sidebar-container">
+  <h2 class="ui medium top attached header mt-0">{{ _('Disclaimers') }}</h2>
+  <div id="licenses" class="ui segment bottom attached rdm-sidebar">
+    <ul class="details-list m-0 p-0">
+      <li id="disclaimer" class="has-popup">
+        <div id="title-disclaimer"
+            class="license clickable"
+            tabindex="0"
+            aria-haspopup="dialog"
+            aria-expanded="false"
+            role="button"
+            aria-label=""
+        >
+          <span class="title-text">
+            Limitations of further sharing
+          </span>
+        </div>
+        <div id="description-disclaimer"
+              class="licenses-description ui flowing popup transition hidden"
+              role="dialog"
+              aria-labelledby="title-disclaimer"
+        >
+          <i role="button" tabindex="0" class="close icon text-muted" aria-label="{{ _('Close') }}"></i>
+
+          <div id="disclaimer-description" class="description">
+            <span class="text-muted">
+              Current, former and future COMMUNITY members are not authorised to distribute
+              this dataset and the corresponding metadata outside the COMMUNITY in which
+              it was originally shared. <a href="/about/disclaimer" target="_blank">Read disclaimer.</a>
+            </span>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/templates/semantic-ui/security/email/reset_instructions.html
+++ b/templates/semantic-ui/security/email/reset_instructions.html
@@ -1,0 +1,7 @@
+<p>
+    By logging in, you agree to the limitations on the redistribution of data and metadata available on the BIG-MAP Archive.
+</p>
+<p>
+    More information in the BIG-MAP Archive <a href="{{ config.SITE_UI_URL }}/about/disclaimer">disclaimer</a>.
+</p>
+<p><a href="{{ reset_link }}">{{ _('Click here to reset your password') }}</a></p>


### PR DESCRIPTION
* replaces BIG-MAP Archive license
* adds license page
* adds disclaimer page and disclaimer link on record
* adds note about disclaimer in Login page and Forgot password page
* adds note about disclaimer in the share with community modal on upload form
* adds note about disclaimer in email to change password